### PR TITLE
fix: modify PR template to close issues on merges

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,4 +1,4 @@
-# Issue #issue_number or [TITLE]
+# Fixes #issue_number or [TITLE]
 
 **Summary:**
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# Issue #issue_number or [TITLE]
+# Fixes #issue_number or [TITLE]
 
 **Summary:**
 


### PR DESCRIPTION
# Modify PR template to close issues on merges

**Summary:**

It is possible to automatically close issues when PRs are merged. This is what it adds.

**Changes:**

* modify PR template to close issues on merges

**Dependencies:**

No dependency